### PR TITLE
Different offsets for "[Next Misson]" and "<<Retry "

### DIFF
--- a/client/ui/menu/ui_arming.qc
+++ b/client/ui/menu/ui_arming.qc
@@ -223,9 +223,8 @@ void() weaponGroupPanelListener={
   if(menu_checkMouseInBounds(cursorpos, WEPNGRP_ORG_A, WEPNGRP_SIZE_A, TRUE)){
     found = listListener(WEPNGRP_ORG_A, cursorpos, WEPNGRP_SIZE_A, gui_percentToPixelRawVec('18.56 20'), WEPNGRP_CNT_A, 0);
     found = WEPBITS[found];
-    if((CLIENT_MENU_nex_grp1 & found)){
+    if((CLIENT_MENU_nex_grp1 & found) ){
       CLIENT_MENU_nex_grp1 = CLIENT_MENU_nex_grp1 - (CLIENT_MENU_nex_grp1 & found);
-      
     }else{
       CLIENT_MENU_nex_grp1 = CLIENT_MENU_nex_grp1 | found;
     }
@@ -622,11 +621,14 @@ void(vector ofs) menu_arming_WeaponGroupPanel={
     if( hardpoint.icon != "" ){
       drawpic(lofs + gui_percentToPixelRawVec('16 -8'), hardpoint.icon, gui_percentToPixelRawVec('20 20'), '1 1 1', 1,0);
     }
-    gui_renderTintImage((CLIENT_MENU_nex_grp1 & bit),  lofs + gui_percentToPixelRawVec('40 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
-    gui_renderTintImage((CLIENT_MENU_nex_grp2 & bit),  lofs + gui_percentToPixelRawVec('60 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
-    gui_renderTintImage((CLIENT_MENU_nex_grp3 & bit),  lofs + gui_percentToPixelRawVec('80 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
-    gui_renderTintImage((CLIENT_MENU_nex_grp4 & bit),  lofs + gui_percentToPixelRawVec('100 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
-    gui_renderTintImage((CLIENT_MENU_nex_grp5 & bit),  lofs + gui_percentToPixelRawVec('120 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
+    if( !(hardpoint.damageType & DMG_MSC) ){    
+      gui_renderTintImage((CLIENT_MENU_nex_grp1 & bit),  lofs + gui_percentToPixelRawVec('40 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
+      gui_renderTintImage((CLIENT_MENU_nex_grp2 & bit),  lofs + gui_percentToPixelRawVec('60 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
+      gui_renderTintImage((CLIENT_MENU_nex_grp3 & bit),  lofs + gui_percentToPixelRawVec('80 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
+      gui_renderTintImage((CLIENT_MENU_nex_grp4 & bit),  lofs + gui_percentToPixelRawVec('100 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
+      gui_renderTintImage((CLIENT_MENU_nex_grp5 & bit),  lofs + gui_percentToPixelRawVec('120 -3'), UI_DEF_BOX_256, groupButtonSize, CLR_DEF_ARM_OK, 1, 0);
+    }
+    
     bit = bit * 2;
     lst_idx = lst_idx + 1;
     hardpoint = hardpoint.w_slot;

--- a/client/ui/menu/ui_debrief.qc
+++ b/client/ui/menu/ui_debrief.qc
@@ -57,7 +57,6 @@ void(vector panelOffset) menu_debrief_header={
   //Next Mission Button
   local vector nextMissionOrg;
   local vector nextMissionLabelOrg;
-  local float nextMissionLen;
   
   nextMissionOrg_x = VIEW_MAX_x - gui_percentXRaw(138);
   nextMissionOrg_y = gui_percentYRaw(6);
@@ -68,12 +67,12 @@ void(vector panelOffset) menu_debrief_header={
   local string missionStatus;
   if( MENU_DEBRIEF_status ){
     missionStatus = "[Next Mission]";
+    nextMissionLabelOrg_x = nextMissionOrg_x + gui_percentXRaw(16);
   }
   else{
     missionStatus = "<< Retry ";
+    nextMissionLabelOrg_x = nextMissionOrg_x + gui_percentXRaw(32);
   }
-  nextMissionLen = stringwidth( missionStatus, 0, '18 14');
-  nextMissionLabelOrg_x = nextMissionOrg_x + gui_percentXRaw(16);
   nextMissionLabelOrg_y = gui_percentYRaw(10);
   drawstring( nextMissionLabelOrg, missionStatus, '18 14', '1 1 1', 1, 0);
   


### PR DESCRIPTION
Added different offsets for "[Next Misson]" and "<<Retry " so both are centered on the button. "<<Retry " was a bit off center last commit.

Seems I submitted the previous pull request  a little too soon. Should have done this first. 

Thanks for accepting my work!