### PR TITLE
patched: regression with Server Info logic and GAMETYPE value handling in CSQC.

### DIFF
--- a/client/client_main.qc
+++ b/client/client_main.qc
@@ -2,7 +2,7 @@
 void() CSQC_Init =
 {
   local float i, cnt;
-  registercvar("gamemode", "0");
+  registercvar("gamemode", "1");
   registercommand("fog");
   //registercvar("cl_hud_sway", "1");
   registercvar("cl_team", ftos(cvar("cl_team")));
@@ -517,6 +517,9 @@ void(string s) CSQC_Parse_StuffCmd =
   argc = tokenize(s);
   if(argv(0) == "m"){
     if(argv(1) == "msn"){
+      if( cvar("developer") ){
+        dprint(sprintf("CSQC_Parse_StuffCmd().s = %s\n", s));  //debug
+      }
       cl_get_msnfile( argv(2) );
       return;
     }
@@ -526,25 +529,6 @@ void(string s) CSQC_Parse_StuffCmd =
     }
   }
   else{
-    if( argv(0) == "svinfo" ){
-      //receives the SV_SERVERINFO string
-      SV_STARTTIME = stof(argv(1) );
-      SV_MISSIONSTATUS = stof(argv(2) );
-      cvar_set("gamemode", argv(3) );
-      SV_SERVERFLAGS = stof(argv(4) );
-      SV_TIMELIMIT = stof(argv(5));
-      SV_WORLDTYPE = stof(argv(6));
-      if( cvar("gamemode") == GAMEMODE_CAMPAIGN ){
-        cvar_set("saveslot", argv(7) );
-      }
-      else{
-        cvar_set("saveslot", "0");
-      }
-      if(CLIENT_player_state == PLAYER_CONNECT ){
-        cl_set_savepath( cvar("gamemode"), (SV_SERVERFLAGS & SVFLAG_ITEMOVER) );
-      }
-      return;
-    }
     if( argv(0) == "svabout" ){
       lenAdjust = strlen(s) - 8;
       tempAbout = substring(s, 8, lenAdjust );

--- a/client/input_events.qc
+++ b/client/input_events.qc
@@ -33,7 +33,7 @@ float(float inputEventType, float scanx, float chary, float devid) handle_input=
 //=====================
   
 //Stops animatic playback by pressing space bar
-  if( cvar("gamemode") == GAMEMODE_CAMPAIGN ){
+  if( SV_GAMETYPE == GAMEMODE_CAMPAIGN ){
     //not sure if skipping cut-scenes during co-op games is even possible.
     if( ANM_FILE_STATUS == 1 ){
       if( scanx == K_SPACE ){

--- a/client/network/receive_entities.qc
+++ b/client/network/receive_entities.qc
@@ -152,16 +152,16 @@ void() receive_ent_bindData={
   also Server Mission Status and Results
 */
 void() client_state_events={
-  local float gameType;
+  //local float gameType;
   local float timeVal;
   
-  gameType = cvar("gamemode");
+ //gameType = cvar("gamemode");
   
   //SERVER EVENTS
   if( SV_MISSION_STATUS_PREV != SV_MISSIONSTATUS ){
     //Server Event - end of map
     if( (SV_MISSION_STATUS_PREV != MISSION_STATUS_OVER) && (SV_MISSIONSTATUS == MISSION_STATUS_OVER) ){
-      if( gameType == GAMEMODE_CAMPAIGN ){
+      if( SV_GAMETYPE == GAMEMODE_CAMPAIGN ){
         if( SV_MISSION_RESULT == MISSION_RESULT_WIN ){
           hud_event_enqueue( HUD_EVENT_MISSION_COMPLETE, 1 );
         }
@@ -184,6 +184,9 @@ void() client_state_events={
   
     //EVENT - CLIENT FIRST TIME CONNECT---
     if( (CLIENT_player_state_prev == PLAYER_CONNECT) && (CLIENT_player_state == PLAYER_SPAWN) ){
+      if( cvar("developer") ){
+        dprint(sprintf("EVENT - CLIENT FIRST TIME CONNECT--- SV_GAMETYPE = %s\n", ftos(SV_GAMETYPE))); //debug
+      }
       //mission file load check
       if(MSN_FILEFOUND){
         if(MSN_LOADED == FALSE){
@@ -224,7 +227,7 @@ void() client_state_events={
     
     //EVENT - CLIENT DEATH----------------
     if( (CLIENT_player_state_prev != PLAYER_DEAD) && (CLIENT_player_state == PLAYER_DEAD) ){
-      if( gameType == GAMEMODE_CAMPAIGN ){
+      if( SV_GAMETYPE == GAMEMODE_CAMPAIGN ){
         if( SV_MISSIONSTATUS == MISSION_RESULT_WIN ){
           te_mission_win();
         }
@@ -276,7 +279,7 @@ void() client_state_events={
     if( (CLIENT_player_state_prev == PLAYER_DEAD) && (CLIENT_player_state == PLAYER_REDEPLOY) ){
       menu_enter( MENU_CONNECT_ACTIVE );
       MENU_button_delay = servertime + 1;
-      if( gameType == GAMEMODE_COOP ){
+      if( SV_GAMETYPE == GAMEMODE_COOP ){
         MENU_respawn_cool = servertime + SERVER_RESPAWN_COOL_COOP;
       }
       else{
@@ -289,13 +292,13 @@ void() client_state_events={
     
     //EVENT - CLIENT END OF DM/TDM
     if( (CLIENT_player_state_prev != PLAYER_INTERMSN) && (CLIENT_player_state == PLAYER_INTERMSN) ){
-      if( gameType == GAMEMODE_CAMPAIGN ){
+      if( SV_GAMETYPE == GAMEMODE_CAMPAIGN ){
         setcursormode( 0 );
         menu_exit();
         return;
       }
       menu_enter( MENU_SCORE_ACTIVE );
-      if(  gameType == GAMEMODE_COOP  ){
+      if(  SV_GAMETYPE == GAMEMODE_COOP  ){
         MENU_DEBRIEF_time_elapsed = -1;
         ui_set_mission_status( SV_MISSION_RESULT );
         MENU_respawn_cool_start = servertime + SERVER_SCORE_TIME_COOP;
@@ -312,7 +315,7 @@ void() client_state_events={
     //EVENT - CLIENT connect during end of round
     if( (CLIENT_player_state_prev != PLAYER_SPAWN) && (CLIENT_player_state == PLAYER_INTERMSN) ){
       menu_enter( MENU_SCORE_ACTIVE );
-      if( gameType == GAMEMODE_DM ){
+      if( SV_GAMETYPE == GAMEMODE_DM ){
         
       }
       //MENU_button_delay = servertime + 1;
@@ -519,7 +522,6 @@ void() client_get_serverinfo={
   SV_MISSIONSTATUS = ReadByte();
   SV_GAMETYPE = ReadByte();
   SV_SERVERFLAGS = ReadLong();
-  dprint(sprintf("SV_SERVERFLAGS = %s \n", ftos(SV_SERVERFLAGS)));  //debug
   SV_TIMELIMIT = ReadCoord();
   SV_WORLDTYPE = ReadByte();
   if( SV_GAMETYPE == GAMEMODE_CAMPAIGN ){
@@ -534,9 +536,9 @@ void() client_get_serverinfo={
     SV_NEXTMAP = strzone(name);
   }
   
-  cvar_set("gamemode", ftos(SV_GAMETYPE));
+  //cvar_set("gamemode", ftos(SV_GAMETYPE));
   if(CLIENT_player_state == PLAYER_CONNECT ){
-    cl_set_savepath( cvar("gamemode"), (SV_SERVERFLAGS & SVFLAG_ITEMOVER) );
+    cl_set_savepath(SV_GAMETYPE, (SV_SERVERFLAGS & SVFLAG_ITEMOVER) );
   }
 };
 

--- a/client/ui/hud/hud_tacmap.qc
+++ b/client/ui/hud/hud_tacmap.qc
@@ -148,19 +148,19 @@ void() hud_render_tactical_map={
 
 void() hud_render_scoreboard={
   local vector panelOrg;
-  local float gameMode;
+  //local float gameMode;
   
   panelOrg_x = VIEW_MAX_x - gui_percentXRaw(150);
   panelOrg_y = VIEW_ORG_y + gui_percentYRaw(2);
 
-  gameMode = cvar("gamemode");
-  if( gameMode == GAMEMODE_TEAMDM ){
+  //gameMode = cvar("gamemode");
+  if( SV_GAMETYPE == GAMEMODE_TEAMDM ){
     hud_render_scoreboard_tdm( panelOrg );
   }
-  else if( gameMode == GAMEMODE_DM ){
+  else if( SV_GAMETYPE == GAMEMODE_DM ){
     hud_render_scoreboard_dm( panelOrg );
   }
-  else if( gameMode == GAMEMODE_COOP ){
+  else if( SV_GAMETYPE == GAMEMODE_COOP ){
     hud_render_scoreboard_dm( panelOrg );
   }
 }; 

--- a/client/ui/menu/ui_connect.qc
+++ b/client/ui/menu/ui_connect.qc
@@ -76,15 +76,15 @@ void() menu_connect_drawFrame={
   
   scoreboard_think();
   
-  if( cvar("gamemode") == GAMEMODE_TEAMDM ){
+  if( SV_GAMETYPE == GAMEMODE_TEAMDM ){
     menu_connect_render_teamdm( topleftroot );
     return;
   }
-  else if( cvar("gamemode") == GAMEMODE_DM ){
+  else if( SV_GAMETYPE == GAMEMODE_DM ){
     menu_connect_render_dm(topleftroot);
     return;
   }
-  else if( cvar("gamemode") == GAMEMODE_COOP ){
+  else if( SV_GAMETYPE == GAMEMODE_COOP ){
     menu_connect_render_coop( topleftroot );
   }
 };
@@ -102,7 +102,7 @@ void( vector menuOrg ) menu_connect_draw_bar={
   ui_navbutton_disconnect_draw( menuOrg );
   if( SV_MISSIONSTATUS <= MISSION_STATUS_ACTIVE ){
     ui_navbutton_connect_draw( enterOfs );
-    if( cvar("gamemode") == GAMEMODE_TEAMDM ){
+    if( SV_GAMETYPE == GAMEMODE_TEAMDM ){
       switchOfs_x = VIEW_CTR_x - gui_percentXRaw( UI_NAVBAR_TEAM_SIZE_x / 2 );
       switchOfs_y = menuOrg_y;
       ui_navbutton_team_draw( switchOfs );

--- a/client/ui/menu/ui_debrief.qc
+++ b/client/ui/menu/ui_debrief.qc
@@ -17,7 +17,7 @@ void() menu_debriefListener_onClick={
     if( menu_checkMouseInBounds(cursorpos, MENU_DEBRIEF_BUTTON_ORG_mission, gui_percentToPixelRawVec('128 24'), TRUE) ){
       if( servertime > MENU_DEBRIEF_time_elapsed ){
         //Single player 
-        if( cvar("gamemode") == GAMEMODE_CAMPAIGN ){
+        if( SV_GAMETYPE == GAMEMODE_CAMPAIGN ){
           if( !(SV_SERVERFLAGS & SVFLAG_NOSAVE) ){
             cl_savefile_save();
           }

--- a/client/ui/menu/ui_menu_controller.qc
+++ b/client/ui/menu/ui_menu_controller.qc
@@ -213,17 +213,13 @@ void() menu_exit={
 
 float() menu_connect_choice={
   local float choice;
-  switch( cvar("gamemode") ){
+  switch( SV_GAMETYPE ){
     case GAMEMODE_CAMPAIGN:
       choice = MENU_BRIEF_ACTIVE;
       INFO_SWITCH = 1;
       break;
-    case GAMEMODE_COOP:
-      //todo
-      choice = MENU_CONNECT_ACTIVE;
-      break;
     default:
-      choice = MENU_CONNECT_ACTIVE;     
+      choice = MENU_CONNECT_ACTIVE;
       break;
   }
   return choice;
@@ -400,7 +396,7 @@ void( vector rowOfs, float itr, entity playerRow, float showScore) menu_player_r
   local float statusLen;
   local string playerStatus;
   playerStatusOfs = playerScoreOfs + gui_percentToPixelRawVec('49 0');
-  if( (SV_SERVERFLAGS & SVFLAG_NOSTATUS) && (cvar("gamemode") != GAMEMODE_COOP) ){
+  if( (SV_SERVERFLAGS & SVFLAG_NOSTATUS) && (SV_GAMETYPE != GAMEMODE_COOP) ){
     playerStatus = "<hidden>";
     statusColor = CLR_DEF_ARM_THREEQ;
   }

--- a/client/ui/menu/ui_score.qc
+++ b/client/ui/menu/ui_score.qc
@@ -51,7 +51,7 @@ void() menu_score_drawFrame={
   //Navbar
   menu_score_draw_bar( VIEW_ORG + gui_percentToPixelRawVec('9.984 7.488') );
   
-  if( cvar("gamemode") == GAMEMODE_COOP ){
+  if( SV_GAMETYPE == GAMEMODE_COOP ){
     menu_score_coop_nav( VIEW_ORG + gui_percentToPixelRawVec('9.984 7.488') );
     
     menu_score_coop_server_info( topleftroot + gui_percentToPixelRawVec('32 32') );
@@ -64,7 +64,7 @@ void() menu_score_drawFrame={
     
     menu_score_coop_client_stats(topleftroot + gui_percentToPixelRawVec('56 220'));
   }
-  else if( cvar("gamemode") == GAMEMODE_TEAMDM ){
+  else if( SV_GAMETYPE == GAMEMODE_TEAMDM ){
     //nav bar
     menu_score_tdm_nav(  VIEW_ORG + gui_percentToPixelRawVec('9.984 7.488') ) ;
     //mission info - TDM
@@ -78,7 +78,7 @@ void() menu_score_drawFrame={
     //player list
     menu_connect_draw_players_team( topleftroot + gui_percentToPixelRawVec('10 282') );
   }
-  else if( cvar("gamemode") == GAMEMODE_DM ){
+  else if( SV_GAMETYPE == GAMEMODE_DM ){
     menu_score_dm_nav( VIEW_ORG + gui_percentToPixelRawVec('9.984 7.488') );
     //mission info - DM
     menu_serverinfo_basic(topleftroot + gui_percentToPixelRawVec('10 32'));

--- a/client/ui/menu/ui_util.qc
+++ b/client/ui/menu/ui_util.qc
@@ -188,8 +188,8 @@ string() ui_calculate_game_time_string={
   local float t, sec, mint, hr;
   local float endTime;
   endTime = getstatf(STAT_TIMELIMIT) * 60;
-  if( getstatf(STAT_TIMELIMIT) > 0  || cvar("gamemode") == GAMEMODE_COOP ){
-    if( cvar("gamemode") == GAMEMODE_COOP) {
+  if( getstatf(STAT_TIMELIMIT) > 0  || SV_GAMETYPE == GAMEMODE_COOP ){
+    if( SV_GAMETYPE == GAMEMODE_COOP) {
       t = servertime + (servertime - time);
     }
     else{

--- a/main/client_utils.qc
+++ b/main/client_utils.qc
@@ -342,7 +342,6 @@ void(string cmd, float tokens) client_setMission={
     if( stof(argv(2)) == MISSION_RESULT_WIN ){ 
       //mission successful, next map
       savefile_changemap(sv_nextmap); //TODO - fix me
-      dprint(sprintf("sv_nextmap@client_setMission = %s\n", sv_nextmap)); //debug
       if( sv_nextmap == "" || strlen(sv_nextmap) == 0 ){
         stuffcmd(self, "map cin_menu.bsp;togglemenu;cl_ismenu 1;\n");
         return;
@@ -493,9 +492,11 @@ void() client_sendServerAbout={
 void() client_sendMissionFileName={
   local string cmd, msnFile;
   
-  msnFile = mapname;
-  if( world.missionFile != "" ){
+  if( world.missionFile != "" || strlen(world.missionFile) > 0 ){
     msnFile = world.missionFile;
+  }
+  else{
+    msnFile = mapname;
   }
   
   cmd = strcat("m msn ", msnFile, "\n");
@@ -564,6 +565,7 @@ void(entity client, float trackNum, float entFlags) client_sendMusic={
   sends the 'conclusion' data from a mission to the client
 */
 void(entity client, float missionSuccessCheck) client_sendEndMission={
+  
   WriteByte( MSG_ALL, SVC_TEMPENTITY );
   WriteByte( MSG_ALL, TE_MISSION_END );
   WriteByte( MSG_ALL, missionSuccessCheck );
@@ -602,6 +604,24 @@ void() client_send_server_info_update={
   }
   WriteByte( MSG_ALL, MISSION_RESULT );
   WriteString( MSG_ALL, sv_nextmap );
+};
+
+//same thing as above but only on client connect.
+void(entity client) client_send_server_info_connect={
+  msg_entity = client;
+  WriteByte( MSG_ONE, SVC_TEMPENTITY );
+  WriteByte( MSG_ONE, TE_SERVERINFO );
+  WriteLong( MSG_ONE, STARTTIME );
+  WriteByte( MSG_ONE, MISSION_STATUS );
+  WriteByte( MSG_ONE, GAMETYPE );
+  WriteLong( MSG_ONE, serverflags );
+  WriteCoord( MSG_ONE, cvar("timelimit") );
+  WriteByte( MSG_ONE, world.worldtype );
+  if( GAMETYPE == GAMEMODE_CAMPAIGN ){
+    WriteByte( MSG_ONE, cvar("saveslot") );
+  }
+  WriteByte( MSG_ONE, MISSION_RESULT );
+  WriteString( MSG_ONE, sv_nextmap );
 };
 
 /*

--- a/main/extensions/ext_world.qc
+++ b/main/extensions/ext_world.qc
@@ -10,6 +10,19 @@ Overview:
 
 void() world_metal_ini={
   DEPLOY_ID_COUNT = 0;
+  
+  sv_world_load_items();
+  
+  registercvar("campaign", "0", 0); 
+  registercvar("saveslot", "0", 0);
+  registercvar("gamemode", "1", 1);
+  registercvar("cl_hud_alpha", "1", 1);
+  registercvar("cl_hud_color", "0", 1);
+  //registercvar("cl_hud_sway", "0", 1);
+  registercvar("cl_team", "0", 2);
+  registercvar("sv_serverflags", "0", 0);
+  registercvar("sv_about", "Default About Message", 0);
+  
   if( cvar("coop") ){
     GAMETYPE = GAMEMODE_COOP;
   }
@@ -25,20 +38,8 @@ void() world_metal_ini={
   }
   else{
     GAMETYPE = GAMEMODE_CAMPAIGN;
-  } 
+  }
   cvar_set("gamemode", ftos(GAMETYPE));
-
-  sv_world_load_items();
-
-  registercvar("campaign", "0", 0); 
-  registercvar("saveslot", "0", 0);
-  registercvar("gamemode", "0", 0);
-  registercvar("cl_hud_alpha", "1", 1);
-  registercvar("cl_hud_color", "0", 1);
-  //registercvar("cl_hud_sway", "0", 1);
-  registercvar("cl_team", "0", 2);
-  registercvar("sv_serverflags", "0", 0);
-  registercvar("sv_about", "Default About Message", 0);
   
   //Mission unit stat totals
   MISSION_STATUS = MISSION_STATUS_READY;

--- a/main/headers/client_utils.qh
+++ b/main/headers/client_utils.qh
@@ -42,6 +42,7 @@ void( float voiceGroup, float voiceId, float limiter) client_send_ai_voice_all;
 //client command layer
 void() client_sendServerAbout;
 void() client_send_server_info_update;
+void(entity client) client_send_server_info_connect;
 void( entity client ) client_send_campaign_end_data;
 void( entity client ) client_send_dm_end_data;
 

--- a/main/sv/sv_client_api.qc
+++ b/main/sv/sv_client_api.qc
@@ -134,7 +134,8 @@ void() ClientConnect = {
   self.clientcolors = FACTION_PSC;  //faction tracker for network.
   
   self.attackFlag = 0;
-
+  client_data();
+  
   if( world.animaticOnly ) {
     client_playTrack(world.sounds, TRUE);  //play desired music for animatic
     if( world.animaticOnly > 1){
@@ -145,13 +146,14 @@ void() ClientConnect = {
     client_playTrack(3, TRUE);  //entering hangar menu
   }
   
+  client_send_server_info_connect( self );
+  client_sendMissionFileName();
+  
   client_push_player_info();
-  client_data();
   
   if (intermission_running){
     ExitIntermission();
   }
-  client_send_server_info_update();
   client_sendServerAbout();
   self.dphitcontentsmask = (DPCONTENTS_SOLID | DPCONTENTS_WATER | DPCONTENTS_SLIME | DPCONTENTS_LAVA | DPCONTENTS_SKY | DPCONTENTS_BODY | DPCONTENTS_PLAYERCLIP);
 };
@@ -297,7 +299,6 @@ void() PutClientInServer_Campaign={
   
   //handle one-time server connect functions.
   if( self.playerState == PLAYER_CONNECT ){
-    client_sendMissionFileName();
     client_sendFog(self, world.fog_density, world.fog_color, world.fog_alpha, world.fog_dist, world.fade);     
     self.power_timer = 0;
     player_makeObserver();
@@ -351,11 +352,15 @@ void() PutClientInServer_Coop={
   
   //handle one-time server connect functions.
   if( self.playerState == PLAYER_CONNECT ){
-    client_sendMissionFileName();
     client_sendFog(self, world.fog_density, world.fog_color, world.fog_alpha, world.fog_dist, world.fade);     
     self.power_timer = 0;
     player_makeObserver();
-    self.playerState = PLAYER_SPAWN;
+    if(world.animaticOnly > 1){
+      self.playerState = PLAYER_MENU;
+    }
+    else{
+      self.playerState = PLAYER_SPAWN;
+    }
     self.faction = FACTION_PSC; //campaign default
     self.clientcolors = FACTION_PSC;
   }
@@ -364,6 +369,14 @@ void() PutClientInServer_Coop={
   self.th_die = PlayerDieNetwork;
   mapfile_coop_load();
   
+  self.movetype = MOVETYPE_NONE;
+  self.flags = self.flags - (self.flags & FL_FLY);
+  if( world.animaticOnly ){
+    self.playerState = PLAYER_INTERMSN;
+    if(self.clientData != world ){
+      self.clientData.SendFlags = self.clientData.SendFlags | SENDFLAG_EFLAGS;
+    }
+  }
   //if( cvar("developer") ){
   // self.playerState = PLAYER_ACTIVE;
   //}
@@ -384,7 +397,6 @@ void() PutClientInServer_Deathmatch={
   
   //handle one-time server connect functions.
   if( self.playerState == PLAYER_CONNECT ){
-    client_sendMissionFileName();
     client_sendFog(self, world.fog_density, world.fog_color, world.fog_alpha, world.fog_dist, world.fade);
     self.power_timer = 0;
     player_makeObserver();
@@ -416,7 +428,6 @@ void() PutClientInServer_TeamDeathmatch={
   
   //handle one-time server connect functions.
   if( self.playerState == PLAYER_CONNECT ){
-    client_sendMissionFileName();
     client_sendFog(self, world.fog_density, world.fog_color, world.fog_alpha, world.fog_dist, world.fade);     
     self.power_timer = 0;
     player_makeObserver();


### PR DESCRIPTION
+ this had broken TDM/DM join code.
+ this fixes it.
+ CSQC: removed reliance on  cvar("gamemode") in client, instead use SV_GAMETYPE directly.
+ SSQC: fixed issue where cvar("gamemode") wasn't registered before being set.
+ SSQC: new TE_* func to send ServerInfo just to client that is connecting when they connect.